### PR TITLE
fix s3 delete_many

### DIFF
--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -40,6 +40,7 @@ class S3Annex(AnnexBase):
         self._client.delete_object(Bucket=self._bucket_name, Key=key)
 
     def delete_many(self, keys):
+        # casting to tuple because keys might be iterable
         objects = tuple({'Key': key} for key in keys)
         if not objects:
             # this is not just an optimization, boto fails if the array

--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -40,11 +40,13 @@ class S3Annex(AnnexBase):
         self._client.delete_object(Bucket=self._bucket_name, Key=key)
 
     def delete_many(self, keys):
+        objects = tuple({'Key': key} for key in keys)
+        if not objects:
+            return
+
         self._client.delete_objects(
             Bucket=self._bucket_name,
-            Delete={
-                'Objects': tuple({'Key': key} for key in keys),
-            },
+            Delete={'Objects': objects},
         )
 
     def get_file(self, key, out_file):

--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -42,6 +42,8 @@ class S3Annex(AnnexBase):
     def delete_many(self, keys):
         objects = tuple({'Key': key} for key in keys)
         if not objects:
+            # this is not just an optimization, boto fails if the array
+            # is empty
             return
 
         self._client.delete_objects(

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -2,6 +2,7 @@ import base64
 from io import BytesIO
 import json
 
+from mock import Mock
 import pytest
 
 from flask_annex import Annex
@@ -12,7 +13,6 @@ from helpers import AbstractTestAnnex, assert_key_value, get_upload_info
 
 try:
     import boto3
-    from mock import Mock
     from moto import mock_s3
     import requests
 except ImportError:

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -107,6 +107,14 @@ class TestS3Annex(AbstractTestAnnex):
     def assert_app_config_content_length_range(self, conditions):
         assert get_condition(conditions, 'content-length-range') == [0, 100]
 
+    def test_delete_many_empty_list(self, annex, monkeypatch):
+        def assert_not_called(*args, **kwargs):
+            assert(False)
+
+        monkeypatch.setattr(annex._client, 'delete_objects', assert_not_called)
+
+        annex.delete_many(tuple())
+
 
 class TestS3AnnexFromEnv(TestS3Annex):
     @pytest.fixture

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -12,6 +12,7 @@ from helpers import AbstractTestAnnex, assert_key_value, get_upload_info
 
 try:
     import boto3
+    from mock import Mock
     from moto import mock_s3
     import requests
 except ImportError:
@@ -108,12 +109,12 @@ class TestS3Annex(AbstractTestAnnex):
         assert get_condition(conditions, 'content-length-range') == [0, 100]
 
     def test_delete_many_empty_list(self, annex, monkeypatch):
-        def assert_not_called(*args, **kwargs):
-            assert(False)
-
-        monkeypatch.setattr(annex._client, 'delete_objects', assert_not_called)
+        mock = Mock()
+        monkeypatch.setattr(annex._client, 'delete_objects', mock)
 
         annex.delete_many(tuple())
+
+        mock.assert_not_called()
 
 
 class TestS3AnnexFromEnv(TestS3Annex):

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
 
     s3: moto
     s3: requests
+    s3: mock
 
 commands =
     s3: pip install -e .[s3]

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,12 @@ usedevelop = True
 
 deps =
     flake8
+    mock
     pytest
     pytest-cov
 
     s3: moto
     s3: requests
-    s3: mock
 
 commands =
     s3: pip install -e .[s3]


### PR DESCRIPTION
Couldn't find any documentation around this issue, but I empirically discovered that `delete_objects` with an empty array causes the request to fail. Also, this is a valid optimization anyway.