### PR TITLE
Add a “post_data” field that returns s3 annex post info as a list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 
 language: python
 python:
-  - "2.7"
-  - "3.5"
   - "3.6"
   - "pypy"
 
@@ -12,8 +10,6 @@ env:
 
 matrix:
   include:
-    - python: "2.7"
-      env: TOXENV=py-base
     - python: "3.6"
       env: TOXENV=py-base
     - # TODO: Remove this workaround once travis-ci/travis-ci#9815 is fixed.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Efficient integration of external storage services for
 [Flask](http://flask.pocoo.org/).
 
+Run `pip install -e .[dev,s3]` to install for development and with `S3` support
+
 [![Codecov][codecov-badge]][codecov]
 
 [build-badge]: https://img.shields.io/travis/4Catalyzer/flask-annex/master.svg

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Efficient integration of external storage services for
 [Flask](http://flask.pocoo.org/).
 
-Run `pip install -e .[dev,s3]` to install for development and with `S3` support
+Run `pip install -e .[s3,tests]` to install for development and with `S3` support
 
 [![Codecov][codecov-badge]][codecov]
 

--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -132,6 +132,5 @@ class S3Annex(AnnexBase):
         return {
             'method': 'POST',
             'url': post_info['url'],
-            'data': post_info['fields'],
             'post_data': tuple(post_info['fields'].items())
         }

--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -132,5 +132,5 @@ class S3Annex(AnnexBase):
         return {
             'method': 'POST',
             'url': post_info['url'],
-            'post_data': tuple(post_info['fields'].items())
+            'post_data': tuple(post_info['fields'].items()),
         }

--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -133,4 +133,5 @@ class S3Annex(AnnexBase):
             'method': 'POST',
             'url': post_info['url'],
             'data': post_info['fields'],
+            'post_data': tuple(post_info['fields'].items())
         }

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,12 @@ setup(
         'Flask >= 0.10',
     ),
     extras_require={
+        'dev': (
+            'pytest',
+            'mock',
+            'moto',
+            'requests',
+        ),
         's3': ('boto3 >= 1.4.0',),
     },
     cmdclass={

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ),

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,9 @@ setup(
     extras_require={
         's3': ('boto3 >= 1.4.0',),
         'tests': (
-            'pytest',
             'mock',
             'moto',
+            'pytest',
             'requests',
         ),
     },

--- a/setup.py
+++ b/setup.py
@@ -49,13 +49,13 @@ setup(
         'Flask >= 0.10',
     ),
     extras_require={
-        'dev': (
+        's3': ('boto3 >= 1.4.0',),
+        'tests': (
             'pytest',
             'mock',
             'moto',
             'requests',
         ),
-        's3': ('boto3 >= 1.4.0',),
     },
     cmdclass={
         'clean': system('rm -rf build dist *.egg-info'),

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,7 +19,7 @@ def assert_key_value(annex, key, value):
 def get_upload_info(client, key, **kwargs):
     response = client.get('/upload_info/{}'.format(key), **kwargs)
     return json.loads(
-        response.get_data(as_text=True), object_pairs_hook=OrderedDict
+        response.get_data(as_text=True), object_pairs_hook=OrderedDict,
     )
 
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from io import BytesIO
 import json
 
@@ -17,7 +18,9 @@ def assert_key_value(annex, key, value):
 
 def get_upload_info(client, key, **kwargs):
     response = client.get('/upload_info/{}'.format(key), **kwargs)
-    return json.loads(response.get_data(as_text=True))
+    return json.loads(
+        response.get_data(as_text=True), object_pairs_hook=OrderedDict
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from io import BytesIO
 import json
 
@@ -18,9 +17,7 @@ def assert_key_value(annex, key, value):
 
 def get_upload_info(client, key, **kwargs):
     response = client.get('/upload_info/{}'.format(key), **kwargs)
-    return json.loads(
-        response.get_data(as_text=True), object_pairs_hook=OrderedDict,
-    )
+    return json.loads(response.get_data(as_text=True))
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -84,6 +84,11 @@ class TestS3Annex(AbstractTestAnnex):
         assert upload_info['url'] == 'https://flask-annex.s3.amazonaws.com/'
         assert upload_info['data']['key'] == 'foo/qux.txt'
         assert upload_info['data']['Content-Type'] == 'text/plain'
+        assert upload_info['post_data'][0] == ['Content-Type', 'text/plain']
+        assert upload_info['post_data'][1] == ['key', 'foo/qux.txt']
+        assert upload_info['post_data'][2] == ['AWSAccessKeyId', 'foobar_key']
+        assert upload_info['post_data'][3][0] == 'policy'
+        assert upload_info['post_data'][4][0] == 'signature'
 
         conditions = get_policy(upload_info)['conditions']
         assert get_condition(conditions, 'bucket') == 'flask-annex'

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -32,12 +32,12 @@ def bucket_name():
 def get_policy(upload_info):
     # filter for the "policy" field; there should only be one instance
     policy_items = list(
-        filter(lambda x: x[0] == 'policy', upload_info['post_data'])
+        filter(lambda x: x[0] == 'policy', upload_info['post_data']),
     )
     policy_item = policy_items[0]
 
     return json.loads(
-        base64.urlsafe_b64decode(policy_item[1].encode(),).decode(),
+        base64.urlsafe_b64decode(policy_item[1].encode()).decode(),
     )
 
 
@@ -122,7 +122,7 @@ class TestS3Annex(AbstractTestAnnex):
 
         # filter for the "key" field; there should be only one instance
         key_items = list(
-            filter(lambda x: x[0] == 'key', upload_info['post_data'])
+            filter(lambda x: x[0] == 'key', upload_info['post_data']),
         )
         key_item = key_items[0]
         assert key_item[1] == 'foo/qux.@@nonexistent'

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -30,10 +30,14 @@ def bucket_name():
 
 
 def get_policy(upload_info):
+    # filter for the "policy" field; there should only be one instance
+    policy_items = list(
+        filter(lambda x: x[0] == 'policy', upload_info['post_data'])
+    )
+    policy_item = policy_items[0]
+
     return json.loads(
-        base64.urlsafe_b64decode(
-            upload_info['data']['policy'].encode(),
-        ).decode(),
+        base64.urlsafe_b64decode(policy_item[1].encode(),).decode(),
     )
 
 
@@ -82,8 +86,6 @@ class TestS3Annex(AbstractTestAnnex):
 
         assert upload_info['method'] == 'POST'
         assert upload_info['url'] == 'https://flask-annex.s3.amazonaws.com/'
-        assert upload_info['data']['key'] == 'foo/qux.txt'
-        assert upload_info['data']['Content-Type'] == 'text/plain'
         assert upload_info['post_data'][0] == ['Content-Type', 'text/plain']
         assert upload_info['post_data'][1] == ['key', 'foo/qux.txt']
         assert upload_info['post_data'][2] == ['AWSAccessKeyId', 'foobar_key']
@@ -117,8 +119,17 @@ class TestS3Annex(AbstractTestAnnex):
 
         assert upload_info['method'] == 'POST'
         assert upload_info['url'] == 'https://flask-annex.s3.amazonaws.com/'
-        assert upload_info['data']['key'] == 'foo/qux.@@nonexistent'
-        assert 'Content-Type' not in upload_info['data']
+
+        # filter for the "key" field; there should be only one instance
+        key_items = list(
+            filter(lambda x: x[0] == 'key', upload_info['post_data'])
+        )
+        key_item = key_items[0]
+        assert key_item[1] == 'foo/qux.@@nonexistent'
+
+        # should not have 'Content-Type' in the post data
+        assert all(post_data_pair[0] != 'Content-Type'
+                   for post_data_pair in upload_info['post_data'])
 
     def test_delete_many_empty_list(self, annex, monkeypatch):
         mock = Mock()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37}-{base,s3}
+envlist = py{36,37}-{base,s3}
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
This is mainly used in some consumers that rewrite dictionary keys between camel case <==> python “lower case with underscore” syntax