### PR TITLE
Add no redirect option to send_file

### DIFF
--- a/flask_annex/base.py
+++ b/flask_annex/base.py
@@ -23,7 +23,7 @@ class AnnexBase:
     def save_file(self, key, in_file):
         raise NotImplementedError()
 
-    def send_file(self, key, no_redirect):
+    def send_file(self, key):
         raise NotImplementedError()
 
     def get_upload_info(self, key):

--- a/flask_annex/base.py
+++ b/flask_annex/base.py
@@ -23,7 +23,7 @@ class AnnexBase:
     def save_file(self, key, in_file):
         raise NotImplementedError()
 
-    def send_file(self, key):
+    def send_file(self, key, no_redirect):
         raise NotImplementedError()
 
     def get_upload_info(self, key):

--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -84,7 +84,7 @@ class S3Annex(AnnexBase):
                 in_file, self._bucket_name, key, extra_args,
             )
 
-    def send_file(self, key, no_redirect = False):
+    def send_file(self, key, **kwargs):
         url = self._client.generate_presigned_url(
             ClientMethod="get_object",
             Params={
@@ -96,7 +96,7 @@ class S3Annex(AnnexBase):
             },
             ExpiresIn=self._expires_in,
         )
-        return url if no_redirect else flask.redirect(url)
+        return url if kwargs.get("no_redirect") else flask.redirect(url)
 
     def get_upload_info(self, key):
         fields = {}

--- a/flask_annex/s3.py
+++ b/flask_annex/s3.py
@@ -84,7 +84,7 @@ class S3Annex(AnnexBase):
                 in_file, self._bucket_name, key, extra_args,
             )
 
-    def send_file(self, key):
+    def send_file(self, key, no_redirect = False):
         url = self._client.generate_presigned_url(
             ClientMethod="get_object",
             Params={
@@ -96,7 +96,7 @@ class S3Annex(AnnexBase):
             },
             ExpiresIn=self._expires_in,
         )
-        return flask.redirect(url)
+        return url if no_redirect else flask.redirect(url)
 
     def get_upload_info(self, key):
         fields = {}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,5 +1,6 @@
 import base64
 import json
+import re
 from io import BytesIO
 from unittest.mock import Mock
 
@@ -64,6 +65,13 @@ class TestS3Annex(AbstractTestAnnex):
     def test_save_file_unknown_type(self, annex):
         annex.save_file("foo/qux", BytesIO(b"6\n"))
         assert_key_value(annex, "foo/qux", b"6\n")
+
+    def test_send_file_url(self, annex):
+        url = annex.send_file("foo/qux", True)
+        assert re.match(
+            r"https:\/\/flask-annex\.s3\.amazonaws\.com\/foo\/qux\?response-content-disposition=attachment&AWSAccessKeyId=foobar_key&Signature=.*&Expires=.{10}",
+            url,
+        )
 
     def test_send_file(self, client):
         response = client.get("/files/foo/baz.json")

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -67,7 +67,7 @@ class TestS3Annex(AbstractTestAnnex):
         assert_key_value(annex, "foo/qux", b"6\n")
 
     def test_send_file_url(self, annex):
-        url = annex.send_file("foo/qux", True)
+        url = annex.send_file("foo/qux", no_redirect=True)
         assert re.match(
             r"https:\/\/flask-annex\.s3\.amazonaws\.com\/foo\/qux\?response-content-disposition=attachment&AWSAccessKeyId=foobar_key&Signature=.*&Expires=.{10}",
             url,


### PR DESCRIPTION
Adds an option to return the URL directly as opposed to returning a flask redirect. This moves us closer to being able to return presigned URLs directly from GraphQL and avoid client requests to an exposed REST "redirect" endpoint