### PR TITLE
fix: use python3 cmd explicitly in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ setup(
     },
     cmdclass={
         "clean": system("rm -rf build dist *.egg-info"),
-        "package": system("python setup.py sdist bdist_wheel"),
+        "package": system("python3 setup.py sdist bdist_wheel"),
         "publish": system("twine upload dist/*"),
-        "release": system("python setup.py clean package publish"),
+        "release": system("python3 setup.py clean package publish"),
         "test": system("tox"),
     },
 )


### PR DESCRIPTION
Not sure if this is a good idea or needed but on macOS, python (vs python3) isn't found on later releases I believe. I know Ubuntu has a "python-is-python3" package to make this a bit more transparent.