### PR TITLE
Chore/migrate GitHub actions tox GitHub fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["chore/migrate_github_actions_tox_github"]
+    branches: ["master"]
     tags:
       - "v[0-9].[0-9].[0-9]*"
   pull_request:
@@ -13,7 +13,7 @@ env:
   COVERAGE_PYTHON_VERSION: "3.12"
 
 jobs:
-  tests:  
+  tests:
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
 
@@ -22,19 +22,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      # - uses: actions/checkout@v3
-    # - name: Set up Python ${{ matrix.python-version }}
-    #   uses: actions/setup-python@v4
-    #   with:
-    #     python-version: ${{ matrix.python-version }}
-    # - name: Install dependencies
-    #   run: |
-    #     python -m pip install --upgrade pip
-    #     python -m pip install tox tox-gh-actions
-    # - name: Test with tox
-    #   run: tox
-
-      
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v5"
         with:
@@ -47,7 +34,6 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade coverage[toml] tox tox-gh-actions
       - name: "Run tox targets for ${{ matrix.python-version }}"
-        # run: "python -m tox"
         run: tox
 
       # use a modern Python version for code coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ env:
   COVERAGE_PYTHON_VERSION: "3.12"
 
 jobs:
-  tests:
+  tests:  
     name: "Python ${{ matrix.python-version }}"
     runs-on: "ubuntu-latest"
 
@@ -22,6 +22,19 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
+      # - uses: actions/checkout@v3
+    # - name: Set up Python ${{ matrix.python-version }}
+    #   uses: actions/setup-python@v4
+    #   with:
+    #     python-version: ${{ matrix.python-version }}
+    # - name: Install dependencies
+    #   run: |
+    #     python -m pip install --upgrade pip
+    #     python -m pip install tox tox-gh-actions
+    # - name: Test with tox
+    #   run: tox
+
+      
       - uses: "actions/checkout@v4"
       - uses: "actions/setup-python@v5"
         with:
@@ -34,7 +47,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade coverage[toml] tox tox-gh-actions
       - name: "Run tox targets for ${{ matrix.python-version }}"
-        run: "python -m tox"
+        # run: "python -m tox"
+        run: tox
 
       # use a modern Python version for code coverage
       - uses: "actions/setup-python@v5"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["master"]
+    branches: ["chore/migrate_github_actions_tox_github"]
     tags:
       - "v[0-9].[0-9].[0-9]*"
   pull_request:

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist =
 
 [gh-actions]
 python =
-    3.10: lint, py
-    3.11: lint, py
-    3.12: lint, py
+    3.10: lint, py310
+    3.11: lint, py311
+    3.12: lint, py312
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,9 @@ envlist =
 
 [gh-actions]
 python =
-    3.10: lint, py-base, py-s3
-    3.11: lint, py-base, py-s3
-    3.12: lint, py-base, py-s3
+    3.10: lint, py
+    3.11: lint, py
+    3.12: lint, py
 
 [testenv]
 usedevelop = True

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,12 @@ envlist =
     lint
     py{310, 311, 312}-{base,s3}
 
+[gh-actions]
+python =
+    3.10: lint, py-base, py-s3
+    3.11: lint, py-base, py-s3
+    3.12: lint, py-base, py-s3
+
 [testenv]
 usedevelop = True
 deps =


### PR DESCRIPTION
@c0state This should fix the issue where the tests were skipping.  There was some missing configuration in the usage of `tox-gh-actions`.  See: https://github.com/ymyzk/tox-gh-actions?tab=readme-ov-file#advanced-examples
The successful action: https://github.com/4Catalyzer/flask-annex/actions/runs/10729836844. (it's not running again since this PR isn't against master)